### PR TITLE
feat: allow peer dependencies at any version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   },
   "peerDependencies": {
     "@ionic/react": "*",
-    "react": "^16.8.6",
-    "@testing-library/react": "^9.4.0",
-    "jest": "^24.9.0"
+    "@testing-library/react": "*",
+    "jest": "*",
+    "react": "*"
   },
   "files": [
     "dist/**/*.*"


### PR DESCRIPTION
# Issue

When using NPM 7, `@ionic/react-test-utils` fails to install as it cannot resolve peer dependency `@testing-library/react@^9.4.0`. As of this PR, the Ionic Framework React starter is bundled with `@testing-library/react@^11.2.5`. 

While older versions of NPM did not terminate the installation due to the peer dependency mismatch, NPM 7 does.

# Workaround

At the moment, `@ionic/react-test-utils` can be installed by running `npm i @ionic/react-test-utils --legacy-peer-deps`.

# What this PR updates

As `@testing-library/react`, as well as the other peer dependencies, update at a different cadence than `@ionic/react-test-utils`, star all peer dependencies to avoid the failure of installation with NPM 7. 