### PR TITLE
Update `peerDependencies` to use `>=` scheme.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   },
   "peerDependencies": {
     "@ionic/react": "*",
-    "react": "^16.8.6",
-    "@testing-library/react": "^9.4.0",
-    "jest": "^24.9.0"
+    "react": ">=16.8.6",
+    "@testing-library/react": ">=9.4.0",
+    "jest": ">=24.9.0"
   },
   "files": [
     "dist/**/*.*"


### PR DESCRIPTION
This will prevent warnings on projects that use new majors versions of these libraries.