### PR TITLE
fix(): extend utils to better work with snapshot tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,20 @@ import { mockIonicReact } from '@ionic/react-test-utils';
 mockIonicReact();
 ```
 
+## waitForIonicReact
 
+This function waits for Ionic React to be fully initialized. Use this in tests that need to check the HTML as it will be rendered at runtime, where you aren't able to watch for specific elements to be loaded. For example, snapshot tests that should check a whole component without being tightly coupled to the markup.
 
+```jsx
+import { render } from '@testing-library/react';
+import { waitForIonicReact } from '@ionic/react-test-utils';
+import MyComponent from './MyComponent';
+
+describe('<MyComponent />', () => {
+  it('renders consistently', async () => {
+    const { baseElement } = render(<MyComponent/>);
+    await waitForIonicReact();
+    expect(baseElement).toMatchSnapshot();
+  });
+});
+```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ mockIonicReact();
 
 ## waitForIonicReact
 
-This function waits for Ionic React to be fully initialized. Use this in tests that need to check the HTML as it will be rendered at runtime, where you aren't able to watch for specific elements to be loaded. For example, snapshot tests that should check a whole component without being tightly coupled to the markup.
+This function waits for Ionic React to be fully initialized. Use this in any test that renders Ionic components, to ensure the rendered markup has all classes etc. that Ionic adds at runtime.
 
 ```jsx
 import { render } from '@testing-library/react';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
-        "@ionic/react": "^4.11.10",
+        "@ionic/react": "^6.0.0",
         "@testing-library/jest-dom": "^5.0.2",
         "@testing-library/react": "^9.4.0",
         "@types/jest": "^24.0.23",
@@ -297,27 +297,35 @@
       "dev": true
     },
     "node_modules/@ionic/core": {
-      "version": "4.11.10",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-4.11.10.tgz",
-      "integrity": "sha512-PeonKl5E+VOTBeKDr83y0N/1wbfkZ5jV3PSJTsVPE3Q15LxGEO0GzBvVMgkmkssuqOI3WJPXxYWZVL8ejzSFOQ==",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.16.tgz",
+      "integrity": "sha512-rY9FTKupu6FAeTpbdkaMCPEeV/2ZPCviWSzi6X5RX1OiUP4EdNKj39KvUI++TPA2g8gYmmGsWR0BY3u8j7U/hA==",
       "dev": true,
       "dependencies": {
-        "ionicons": "^4.6.3",
-        "tslib": "^1.10.0"
+        "@stencil/core": "^2.14.2",
+        "ionicons": "^6.0.0",
+        "tslib": "^2.1.0"
       }
     },
+    "node_modules/@ionic/core/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/@ionic/react": {
-      "version": "4.11.10",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-4.11.10.tgz",
-      "integrity": "sha512-EF9H0HDb3MO/E8R2sBACYweQG2OzsHZBdxCYEHTt0lnaOCS2ykB93FK8f0WllP19e5Bx7jembZC4UugwjAxnTQ==",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-6.0.16.tgz",
+      "integrity": "sha512-j5UdRXK3NrR6an2STXOUkZI+GSCUrjxGVmwR9duFLwpd01F2u/Q77WBEpXNlGsrCH2TjBGxKzWJuFKw8db9ICw==",
       "dev": true,
       "dependencies": {
-        "@ionic/core": "4.11.10",
+        "@ionic/core": "^6.0.16",
+        "ionicons": "^6.0.0",
         "tslib": "*"
       },
       "peerDependencies": {
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6"
+        "react": ">=16.8.6",
+        "react-dom": ">=16.8.6"
       }
     },
     "node_modules/@jest/console": {
@@ -523,6 +531,19 @@
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
       "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
       "dev": true
+    },
+    "node_modules/@stencil/core": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.15.0.tgz",
+      "integrity": "sha512-58+FPFpJCJScd5nmqVsZN+qk7aui57wFcMHWzySr1SQzoY8Efst9OPG7XRf27UsNj1DNeEdYWTtdrTfJyn3mZg==",
+      "dev": true,
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=12.10.0",
+        "npm": ">=6.0.0"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "6.12.0",
@@ -4213,10 +4234,26 @@
       }
     },
     "node_modules/ionicons": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-4.6.3.tgz",
-      "integrity": "sha512-cgP+VIr2cTJpMfFyVHTerq6n2jeoiGboVoe3GlaAo5zoSBDAEXORwUZhv6m+lCyxlsHCS3nqPUE+MKyZU71t8Q==",
-      "dev": true
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.1.tgz",
+      "integrity": "sha512-xQekOJsxH82O7oB+3F60zeRggCdND9pJ/k0E6IJDVUGGlCj5mlyFqNgxUimytKgstPGv3S+3EmCxjefvtGgWUg==",
+      "dev": true,
+      "dependencies": {
+        "@stencil/core": "~2.12.0"
+      }
+    },
+    "node_modules/ionicons/node_modules/@stencil/core": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.12.1.tgz",
+      "integrity": "sha512-u24TZ+FEvjnZt5ZgIkLjLpUNsO6Ml3mUZqwmqk81w6RWWz75hgB5p4RFI5rvuErFeh2xvMIGo+pNdG24XUBz1A==",
+      "dev": true,
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=12.10.0",
+        "npm": ">=6.0.0"
+      }
     },
     "node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
@@ -9005,22 +9042,32 @@
       }
     },
     "@ionic/core": {
-      "version": "4.11.10",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-4.11.10.tgz",
-      "integrity": "sha512-PeonKl5E+VOTBeKDr83y0N/1wbfkZ5jV3PSJTsVPE3Q15LxGEO0GzBvVMgkmkssuqOI3WJPXxYWZVL8ejzSFOQ==",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.16.tgz",
+      "integrity": "sha512-rY9FTKupu6FAeTpbdkaMCPEeV/2ZPCviWSzi6X5RX1OiUP4EdNKj39KvUI++TPA2g8gYmmGsWR0BY3u8j7U/hA==",
       "dev": true,
       "requires": {
-        "ionicons": "^4.6.3",
-        "tslib": "^1.10.0"
+        "@stencil/core": "^2.14.2",
+        "ionicons": "^6.0.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
       }
     },
     "@ionic/react": {
-      "version": "4.11.10",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-4.11.10.tgz",
-      "integrity": "sha512-EF9H0HDb3MO/E8R2sBACYweQG2OzsHZBdxCYEHTt0lnaOCS2ykB93FK8f0WllP19e5Bx7jembZC4UugwjAxnTQ==",
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-6.0.16.tgz",
+      "integrity": "sha512-j5UdRXK3NrR6an2STXOUkZI+GSCUrjxGVmwR9duFLwpd01F2u/Q77WBEpXNlGsrCH2TjBGxKzWJuFKw8db9ICw==",
       "dev": true,
       "requires": {
-        "@ionic/core": "4.11.10",
+        "@ionic/core": "^6.0.16",
+        "ionicons": "^6.0.0",
         "tslib": "*"
       }
     },
@@ -9196,6 +9243,12 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
       "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+      "dev": true
+    },
+    "@stencil/core": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.15.0.tgz",
+      "integrity": "sha512-58+FPFpJCJScd5nmqVsZN+qk7aui57wFcMHWzySr1SQzoY8Efst9OPG7XRf27UsNj1DNeEdYWTtdrTfJyn3mZg==",
       "dev": true
     },
     "@testing-library/dom": {
@@ -12189,10 +12242,21 @@
       "dev": true
     },
     "ionicons": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-4.6.3.tgz",
-      "integrity": "sha512-cgP+VIr2cTJpMfFyVHTerq6n2jeoiGboVoe3GlaAo5zoSBDAEXORwUZhv6m+lCyxlsHCS3nqPUE+MKyZU71t8Q==",
-      "dev": true
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.1.tgz",
+      "integrity": "sha512-xQekOJsxH82O7oB+3F60zeRggCdND9pJ/k0E6IJDVUGGlCj5mlyFqNgxUimytKgstPGv3S+3EmCxjefvtGgWUg==",
+      "dev": true,
+      "requires": {
+        "@stencil/core": "~2.12.0"
+      },
+      "dependencies": {
+        "@stencil/core": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.12.1.tgz",
+          "integrity": "sha512-u24TZ+FEvjnZt5ZgIkLjLpUNsO6Ml3mUZqwmqk81w6RWWz75hgB5p4RFI5rvuErFeh2xvMIGo+pNdG24XUBz1A==",
+          "dev": true
+        }
+      }
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dist/**/*.*"
   ],
   "devDependencies": {
-    "@ionic/react": "^4.11.10",
+    "@ionic/react": "^6.0.0",
     "@testing-library/jest-dom": "^5.0.2",
     "@testing-library/react": "^9.4.0",
     "@types/jest": "^24.0.23",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './ionFireEvent';
 export * from './mocks/mockIonicReact';
+export * from './waitForIonicReady';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './ionFireEvent';
 export * from './mocks/mockIonicReact';
-export * from './waitForIonicReady';
+export * from './waitForIonicReact';

--- a/src/mocks/mockIonicReact.ts
+++ b/src/mocks/mockIonicReact.ts
@@ -1,8 +1,9 @@
-import { IonInput } from '@ionic/react';
+import { IonInput, setupIonicReact } from '@ionic/react';
 import { mockController } from './mockController';
 import { mockIonCheckbox } from './mockIonCheckbox';
 
 export function mockIonicReact() {
+  setupIonicReact();
   jest.mock('@ionic/react', () => {
     const rest = jest.requireActual('@ionic/react');
     return {

--- a/src/waitForIonicReact.ts
+++ b/src/waitForIonicReact.ts
@@ -5,7 +5,7 @@
  * loaded. Example: snapshot tests that should check a whole component
  * without being tightly coupled to the markup.
  */
-export async function waitForIonicReady() {
+export async function waitForIonicReact() {
   return new Promise(resolve => {
     requestAnimationFrame(() => {
       requestAnimationFrame(resolve);

--- a/src/waitForIonicReact.ts
+++ b/src/waitForIonicReact.ts
@@ -1,10 +1,3 @@
-/**
- * Waits for Ionic and Stencil to be fully initialized. Use this
- * when your tests need to check the HTML as it will be rendered at
- * runtime, but you aren't able to watch for specific elements to be
- * loaded. Example: snapshot tests that should check a whole component
- * without being tightly coupled to the markup.
- */
 export async function waitForIonicReact() {
   return new Promise(resolve => {
     requestAnimationFrame(() => {

--- a/src/waitForIonicReady.ts
+++ b/src/waitForIonicReady.ts
@@ -1,0 +1,14 @@
+/**
+ * Waits for Ionic and Stencil to be fully initialized. Use this
+ * when your tests need to check the HTML as it will be rendered at
+ * runtime, but you aren't able to watch for specific elements to be
+ * loaded. Example: snapshot tests that should check a whole component
+ * without being tightly coupled to the markup.
+ */
+export async function waitForIonicReady() {
+  return new Promise(resolve => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(resolve);
+    });
+  });
+}


### PR DESCRIPTION
This PR does two things:

1. Adds `setupIonicReact` to `mockIonicReact`. This function is required anyway if you need to render Ionic components in your React tests, so this saves devs the trouble of adding it manually. (The dev dependency for Ionic React is also bumped to v6 to include this function.)
2. Adds a new `waitForIonicReady` util. This can be used to fix problems with tests running too early, like snapshot tests that don't show all classes Ionic adds at runtime. For now, this is just two `raf`s to give Stencil the chance to catch up, but we can extend the functionality later if it becomes needed.