### PR TITLE
fix(): remove setupIonicReact to avoid breaking change to version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ import { mockIonicReact } from '@ionic/react-test-utils';
 mockIonicReact();
 ```
 
+If you are using Ionic v6, you will also need to call `setupIonicReact`:
+
+```js
+import { mockIonicReact } from '@ionic/react-test-utils';
+import { setupIonicReact } from '@ionic/react';
+
+setupIonicReact();
+mockIonicReact();
+```
+
 ## waitForIonicReact
 
 This function waits for Ionic React to be fully initialized. Use this in any test that renders Ionic components, to ensure the rendered markup has all classes etc. that Ionic adds at runtime.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
-        "@ionic/react": "^6.0.0",
+        "@ionic/react": "^4.11.10",
         "@testing-library/jest-dom": "^5.0.2",
         "@testing-library/react": "^9.4.0",
         "@types/jest": "^24.0.23",
@@ -297,35 +297,27 @@
       "dev": true
     },
     "node_modules/@ionic/core": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.16.tgz",
-      "integrity": "sha512-rY9FTKupu6FAeTpbdkaMCPEeV/2ZPCviWSzi6X5RX1OiUP4EdNKj39KvUI++TPA2g8gYmmGsWR0BY3u8j7U/hA==",
+      "version": "4.11.13",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-4.11.13.tgz",
+      "integrity": "sha512-EGin45jCjds4P1AvriujxzpIXKQzQrPQyQAgEEwUybhMNcU/9xC1sf2inG1IwMVdsc6XRBYjWvtqMPWxTWmeCw==",
       "dev": true,
       "dependencies": {
-        "@stencil/core": "^2.14.2",
-        "ionicons": "^6.0.0",
-        "tslib": "^2.1.0"
+        "ionicons": "^4.6.3",
+        "tslib": "^1.10.0"
       }
     },
-    "node_modules/@ionic/core/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
-    },
     "node_modules/@ionic/react": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-6.0.16.tgz",
-      "integrity": "sha512-j5UdRXK3NrR6an2STXOUkZI+GSCUrjxGVmwR9duFLwpd01F2u/Q77WBEpXNlGsrCH2TjBGxKzWJuFKw8db9ICw==",
+      "version": "4.11.13",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-4.11.13.tgz",
+      "integrity": "sha512-4kwASzTn7IQXHO1CDX3AQGODMoKZqcLk86+DQDSjWP4cno3VYq77aFwi812yjtcIu4K7pn4M1zGz9wYyat2S3w==",
       "dev": true,
       "dependencies": {
-        "@ionic/core": "^6.0.16",
-        "ionicons": "^6.0.0",
+        "@ionic/core": "4.11.13",
         "tslib": "*"
       },
       "peerDependencies": {
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
+        "react": "^16.8.6",
+        "react-dom": "^16.8.6"
       }
     },
     "node_modules/@jest/console": {
@@ -531,19 +523,6 @@
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
       "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
       "dev": true
-    },
-    "node_modules/@stencil/core": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.15.0.tgz",
-      "integrity": "sha512-58+FPFpJCJScd5nmqVsZN+qk7aui57wFcMHWzySr1SQzoY8Efst9OPG7XRf27UsNj1DNeEdYWTtdrTfJyn3mZg==",
-      "dev": true,
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
-      }
     },
     "node_modules/@testing-library/dom": {
       "version": "6.12.0",
@@ -4234,26 +4213,10 @@
       }
     },
     "node_modules/ionicons": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.1.tgz",
-      "integrity": "sha512-xQekOJsxH82O7oB+3F60zeRggCdND9pJ/k0E6IJDVUGGlCj5mlyFqNgxUimytKgstPGv3S+3EmCxjefvtGgWUg==",
-      "dev": true,
-      "dependencies": {
-        "@stencil/core": "~2.12.0"
-      }
-    },
-    "node_modules/ionicons/node_modules/@stencil/core": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.12.1.tgz",
-      "integrity": "sha512-u24TZ+FEvjnZt5ZgIkLjLpUNsO6Ml3mUZqwmqk81w6RWWz75hgB5p4RFI5rvuErFeh2xvMIGo+pNdG24XUBz1A==",
-      "dev": true,
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
-      }
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-4.6.3.tgz",
+      "integrity": "sha512-cgP+VIr2cTJpMfFyVHTerq6n2jeoiGboVoe3GlaAo5zoSBDAEXORwUZhv6m+lCyxlsHCS3nqPUE+MKyZU71t8Q==",
+      "dev": true
     },
     "node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
@@ -6660,9 +6623,9 @@
       }
     },
     "node_modules/react": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -6688,6 +6651,33 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/react-is": {
@@ -9042,32 +9032,22 @@
       }
     },
     "@ionic/core": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.0.16.tgz",
-      "integrity": "sha512-rY9FTKupu6FAeTpbdkaMCPEeV/2ZPCviWSzi6X5RX1OiUP4EdNKj39KvUI++TPA2g8gYmmGsWR0BY3u8j7U/hA==",
+      "version": "4.11.13",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-4.11.13.tgz",
+      "integrity": "sha512-EGin45jCjds4P1AvriujxzpIXKQzQrPQyQAgEEwUybhMNcU/9xC1sf2inG1IwMVdsc6XRBYjWvtqMPWxTWmeCw==",
       "dev": true,
       "requires": {
-        "@stencil/core": "^2.14.2",
-        "ionicons": "^6.0.0",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-          "dev": true
-        }
+        "ionicons": "^4.6.3",
+        "tslib": "^1.10.0"
       }
     },
     "@ionic/react": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-6.0.16.tgz",
-      "integrity": "sha512-j5UdRXK3NrR6an2STXOUkZI+GSCUrjxGVmwR9duFLwpd01F2u/Q77WBEpXNlGsrCH2TjBGxKzWJuFKw8db9ICw==",
+      "version": "4.11.13",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-4.11.13.tgz",
+      "integrity": "sha512-4kwASzTn7IQXHO1CDX3AQGODMoKZqcLk86+DQDSjWP4cno3VYq77aFwi812yjtcIu4K7pn4M1zGz9wYyat2S3w==",
       "dev": true,
       "requires": {
-        "@ionic/core": "^6.0.16",
-        "ionicons": "^6.0.0",
+        "@ionic/core": "4.11.13",
         "tslib": "*"
       }
     },
@@ -9243,12 +9223,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
       "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
-      "dev": true
-    },
-    "@stencil/core": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.15.0.tgz",
-      "integrity": "sha512-58+FPFpJCJScd5nmqVsZN+qk7aui57wFcMHWzySr1SQzoY8Efst9OPG7XRf27UsNj1DNeEdYWTtdrTfJyn3mZg==",
       "dev": true
     },
     "@testing-library/dom": {
@@ -12242,21 +12216,10 @@
       "dev": true
     },
     "ionicons": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.1.tgz",
-      "integrity": "sha512-xQekOJsxH82O7oB+3F60zeRggCdND9pJ/k0E6IJDVUGGlCj5mlyFqNgxUimytKgstPGv3S+3EmCxjefvtGgWUg==",
-      "dev": true,
-      "requires": {
-        "@stencil/core": "~2.12.0"
-      },
-      "dependencies": {
-        "@stencil/core": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.12.1.tgz",
-          "integrity": "sha512-u24TZ+FEvjnZt5ZgIkLjLpUNsO6Ml3mUZqwmqk81w6RWWz75hgB5p4RFI5rvuErFeh2xvMIGo+pNdG24XUBz1A==",
-          "dev": true
-        }
-      }
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-4.6.3.tgz",
+      "integrity": "sha512-cgP+VIr2cTJpMfFyVHTerq6n2jeoiGboVoe3GlaAo5zoSBDAEXORwUZhv6m+lCyxlsHCS3nqPUE+MKyZU71t8Q==",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -12891,7 +12854,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "24.9.0",
@@ -14187,9 +14151,9 @@
       }
     },
     "react": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -14209,6 +14173,32 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.3",
         "whatwg-fetch": "^3.0.0"
+      }
+    },
+    "react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dist/**/*.*"
   ],
   "devDependencies": {
-    "@ionic/react": "^6.0.0",
+    "@ionic/react": "^4.11.10",
     "@testing-library/jest-dom": "^5.0.2",
     "@testing-library/react": "^9.4.0",
     "@types/jest": "^24.0.23",

--- a/src/mocks/mockIonicReact.ts
+++ b/src/mocks/mockIonicReact.ts
@@ -1,9 +1,8 @@
-import { IonInput, setupIonicReact } from '@ionic/react';
+import { IonInput } from '@ionic/react';
 import { mockController } from './mockController';
 import { mockIonCheckbox } from './mockIonCheckbox';
 
 export function mockIonicReact() {
-  setupIonicReact();
   jest.mock('@ionic/react', () => {
     const rest = jest.requireActual('@ionic/react');
     return {


### PR DESCRIPTION
In https://github.com/ionic-team/ionic-react-test-utils/pull/34, we added `setupIonicReact` to `mockIonicReact` for developer convenience, but this would require a breaking change as we'd be dropping support for Ionic 4 and 5. This PR reverts that change, and adds a note to the readme about it.