### PR TITLE
fix(waitForIonicReact): wait for DOM stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ describe('<MyComponent />', () => {
 });
 ```
 
-`waitForIonicReact` waits for the DOM to be stable, meaning no markup has changed for a certain period of time. This period is determined by the first parameter, `timeout`, which defaults to 750. There is also a global timeout determined by the second parameter, `maxWaitTime`. This defaults to 5000 (five seconds) and, if hit, will cause the function to fail early. If you find your tests are running too slow or not detecting all Ionic behaviors, try tweaking these values.
+`waitForIonicReact` waits for the DOM to be stable, meaning no markup has changed for a certain period of time. This period is determined by the first parameter, `timeout`, which defaults to 750 milliseconds. There is also a global timeout determined by the second parameter, `maxWaitTime`. This defaults to 5000 milliseconds (five seconds) and, if hit, will cause the function to fail early. If you find your tests are running too slow or not detecting all Ionic behaviors, try tweaking these values.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,5 @@ describe('<MyComponent />', () => {
   });
 });
 ```
+
+`waitForIonicReact` waits for the DOM to be stable, meaning no markup has changed for a certain period of time. This period is determined by the first parameter, `timeout`, which defaults to 750. The second parameter, `retries`, is the maximum number of DOM mutations allowed (default 50) before the function resolves early. If you find your tests are running too slow, try tweaking these values.

--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ describe('<MyComponent />', () => {
 });
 ```
 
-`waitForIonicReact` waits for the DOM to be stable, meaning no markup has changed for a certain period of time. This period is determined by the first parameter, `timeout`, which defaults to 750. The second parameter, `retries`, is the maximum number of DOM mutations allowed (default 50) before the function resolves early. If you find your tests are running too slow, try tweaking these values.
+`waitForIonicReact` waits for the DOM to be stable, meaning no markup has changed for a certain period of time. This period is determined by the first parameter, `timeout`, which defaults to 750. There is also a global timeout determined by the second parameter, `maxWaitTime`. This defaults to 5000 (five seconds) and, if hit, will cause the function to fail early. If you find your tests are running too slow or not detecting all Ionic behaviors, try tweaking these values.

--- a/src/waitForIonicReact.ts
+++ b/src/waitForIonicReact.ts
@@ -1,7 +1,42 @@
-export async function waitForIonicReact() {
-  return new Promise(resolve => {
-    requestAnimationFrame(() => {
-      requestAnimationFrame(resolve);
+/**
+ * Waits for the DOM to be stable, meaning Ionic components have finished loading.
+ * 
+ * @param timeout How long the DOM needs to be stable for (in ms) before resolving.
+ * @param retries How many mutations are allowed before quitting early, to avoid infinite loops.
+ */
+export async function waitForIonicReact(timeout = 750, retries = 50) {
+  return new Promise((resolve, reject) => {
+    let timer: NodeJS.Timeout;
+    
+    const observer = new MutationObserver(() => {
+      if (retries <= 0) {
+        stopWaiting(false, 'Max retries exceeded; DOM has been unstable for too long');
+        return;
+      }
+
+      retries--;
+      resetTimer();
     });
+
+    const resetTimer = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        stopWaiting(true, 'DOM is stable');
+      }, timeout);
+    };
+
+    const stopWaiting = (isStable: boolean, result: string) => {
+      observer.disconnect();
+      if(timer) clearTimeout(timer);
+
+      if (isStable) {
+        resolve(result);
+      } else {
+        reject(result);
+      }
+    };
+
+    observer.observe(document.documentElement, { subtree: true, childList: true, attributes: true, characterData: true });
+    resetTimer(); // initial run
   });
 }

--- a/src/waitForIonicReact.ts
+++ b/src/waitForIonicReact.ts
@@ -2,32 +2,30 @@
  * Waits for the DOM to be stable, meaning Ionic components have finished loading.
  * 
  * @param timeout How long the DOM needs to be stable for (in ms) before resolving.
- * @param retries How many mutations are allowed before quitting early, to avoid infinite loops.
+ * @param maxWaitTime The maximum total time that can pass before rejecting.
  */
-export async function waitForIonicReact(timeout = 750, retries = 50) {
+export async function waitForIonicReact(timeout = 750, maxWaitTime = 5000) {
   return new Promise((resolve, reject) => {
-    let timer: NodeJS.Timeout;
-    
-    const observer = new MutationObserver(() => {
-      if (retries <= 0) {
-        stopWaiting(false, 'Max retries exceeded; DOM has been unstable for too long');
-        return;
-      }
-
-      retries--;
-      resetTimer();
-    });
+    let stabilityTimer: NodeJS.Timeout;
+    const globalTimer = setTimeout(() => {
+      stopWaiting(false,
+        'Timed out waiting for DOM to be stable. Ensure your test doesn\'t make continual page updates, or try increasing maxWaitTime'
+      );
+    }, maxWaitTime);
 
     const resetTimer = () => {
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(() => {
+      if (stabilityTimer) clearTimeout(stabilityTimer);
+      stabilityTimer = setTimeout(() => {
         stopWaiting(true, 'DOM is stable');
       }, timeout);
     };
+    
+    const observer = new MutationObserver(resetTimer);
 
     const stopWaiting = (isStable: boolean, result: string) => {
       observer.disconnect();
-      if (timer) clearTimeout(timer);
+      if (stabilityTimer) clearTimeout(stabilityTimer);
+      clearTimeout(globalTimer);
 
       if (isStable) {
         resolve(result);

--- a/src/waitForIonicReact.ts
+++ b/src/waitForIonicReact.ts
@@ -9,7 +9,7 @@ export async function waitForIonicReact(timeout = 750, maxWaitTime = 5000) {
     let stabilityTimer: NodeJS.Timeout;
     const globalTimer = setTimeout(() => {
       stopWaiting(false,
-        'Timed out waiting for DOM to be stable. Ensure your test doesn\'t make continual page updates, or try increasing maxWaitTime'
+        'Timed out waiting for DOM to be stable. Ensure your test doesn\'t make continual page updates, or try increasing maxWaitTime.'
       );
     }, maxWaitTime);
 

--- a/src/waitForIonicReact.ts
+++ b/src/waitForIonicReact.ts
@@ -27,7 +27,7 @@ export async function waitForIonicReact(timeout = 750, retries = 50) {
 
     const stopWaiting = (isStable: boolean, result: string) => {
       observer.disconnect();
-      if(timer) clearTimeout(timer);
+      if (timer) clearTimeout(timer);
 
       if (isStable) {
         resolve(result);


### PR DESCRIPTION
The old version of this function would sometimes not wait long enough for all of Ionic's async tasks to complete. For example, `ion-item` updates its `ion-focusable` class in the [`componentDidLoad` event](https://github.com/ionic-team/ionic-framework/blob/1b1b1a3800c4d044b4a3e7418f534e9271770ec6/core/src/components/item/item.tsx#L227-L232), which ran after `waitForIonicReact` had already resolved.

This PR updates the function to instead wait for DOM stability. It also includes a couple parameters for customizing the timeouts, for power users who want to speed up their tests a little.